### PR TITLE
Add x86_64 OS architecture support.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,7 +10,7 @@ class hashicorp_install::install {
   }
 
   case $facts['os']['architecture'] {
-    'amd64': {
+    'amd64', 'x86_64': {
       $os_arch = 'amd64'
     }
 


### PR DESCRIPTION
OSes with x86_64 used to result in error message "OS architecture not supported." 

This PR add x86_64 OS arch which is mapped to amd64.